### PR TITLE
Default FC vlun creation type to 'host sees' instead of "Matched Set"

### DIFF
--- a/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
+++ b/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
@@ -5003,8 +5003,8 @@ class TestHPE3PARFCDriver(HPE3PARBaseDriver, test.TestCase):
                 'target_wwn': ['0987654321234', '123456789000987'],
                 'target_discovered': True,
                 'initiator_target_map':
-                    {'123456789012345': ['123456789000987'],
-                     '123456789054321': ['0987654321234']}}}
+                    {'123456789012345': ['0987654321234', '123456789000987'],
+                     '123456789054321': ['0987654321234', '123456789000987']}}}
 
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:
@@ -5022,20 +5022,11 @@ class TestHPE3PARFCDriver(HPE3PARBaseDriver, test.TestCase):
                 mock.call.getHost(self.FAKE_HOST),
                 mock.call.getPorts(),
                 mock.call.getHostVLUNs(self.FAKE_HOST),
-                mock.call.getPorts(),
                 mock.call.createVLUN(
                     self.VOLUME_3PAR_NAME,
                     auto=True,
                     hostname=self.FAKE_HOST,
-                    lun=None,
-                    portPos={'node': 7, 'slot': 1, 'cardPort': 1}),
-                mock.call.getHostVLUNs(self.FAKE_HOST),
-                mock.call.createVLUN(
-                    self.VOLUME_3PAR_NAME,
-                    auto=False,
-                    hostname=self.FAKE_HOST,
-                    lun=90,
-                    portPos={'node': 6, 'slot': 1, 'cardPort': 1}),
+                    lun=None),
                 mock.call.getHostVLUNs(self.FAKE_HOST)]
 
             mock_client.assert_has_calls(
@@ -5197,8 +5188,8 @@ class TestHPE3PARFCDriver(HPE3PARBaseDriver, test.TestCase):
                 'target_wwn': ['0987654321234', '123456789000987'],
                 'target_discovered': True,
                 'initiator_target_map':
-                    {'123456789012345': ['123456789000987'],
-                     '123456789054321': ['0987654321234']}}}
+                    {'123456789012345': ['0987654321234', '123456789000987'],
+                     '123456789054321': ['0987654321234', '123456789000987']}}}
 
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:
@@ -5216,20 +5207,11 @@ class TestHPE3PARFCDriver(HPE3PARBaseDriver, test.TestCase):
                 mock.call.getHost(self.FAKE_HOST),
                 mock.call.getPorts(),
                 mock.call.getHostVLUNs(self.FAKE_HOST),
-                mock.call.getPorts(),
                 mock.call.createVLUN(
                     self.VOLUME_3PAR_NAME,
                     auto=True,
                     hostname=self.FAKE_HOST,
-                    lun=None,
-                    portPos={'node': 7, 'slot': 1, 'cardPort': 1}),
-                mock.call.getHostVLUNs(self.FAKE_HOST),
-                mock.call.createVLUN(
-                    self.VOLUME_3PAR_NAME,
-                    auto=False,
-                    hostname=self.FAKE_HOST,
-                    lun=90,
-                    portPos={'node': 6, 'slot': 1, 'cardPort': 1}),
+                    lun=None),
                 mock.call.getHostVLUNs(self.FAKE_HOST)]
 
             mock_client.assert_has_calls(

--- a/cinder/volume/drivers/hpe/hpe_3par_fc.py
+++ b/cinder/volume/drivers/hpe/hpe_3par_fc.py
@@ -291,61 +291,16 @@ class HPE3PARFCDriver(driver.ManageableVD,
             vlun = None
             if existing_vlun is None:
                 # now that we have a host, create the VLUN
-                nsp = None
-                lun_id = None
-                active_fc_port_list = common.get_active_fc_target_ports()
-
-                if self.lookup_service:
-                    if not init_targ_map:
-                        msg = _("Setup is incomplete. Device mapping "
-                                "not found from FC network. "
-                                "Cannot perform VLUN creation.")
-                        LOG.error(msg)
-                        raise exception.FCSanLookupServiceException(msg)
-
-                    for target_wwn in target_wwns:
-                        for port in active_fc_port_list:
-                            if port['portWWN'].lower() == target_wwn.lower():
-                                nsp = port['nsp']
-                                vlun = common.create_vlun(volume,
-                                                          host,
-                                                          nsp,
-                                                          lun_id=lun_id)
-                                if lun_id is None:
-                                    lun_id = vlun['lun']
-                                break
-                else:
-                    init_targ_map.clear()
-                    del target_wwns[:]
-                    host_connected_nsp = []
-                    for fcpath in host['FCPaths']:
-                        if 'portPos' in fcpath:
-                            host_connected_nsp.append(
-                                common.build_nsp(fcpath['portPos']))
+                if self.lookup_service is not None and numPaths == 1:
+                    nsp = None
+                    active_fc_port_list = common.get_active_fc_target_ports()
                     for port in active_fc_port_list:
-                        if (
-                            port['type'] == common.client.PORT_TYPE_HOST and
-                            port['nsp'] in host_connected_nsp
-                        ):
+                        if port['portWWN'].lower() == target_wwns[0].lower():
                             nsp = port['nsp']
-                            vlun = common.create_vlun(volume,
-                                                      host,
-                                                      nsp,
-                                                      lun_id=lun_id)
-                            target_wwns.append(port['portWWN'])
-                            if vlun['remoteName'] in init_targ_map:
-                                init_targ_map[vlun['remoteName']].append(
-                                    port['portWWN'])
-                            else:
-                                init_targ_map[vlun['remoteName']] = [
-                                    port['portWWN']]
-                            if lun_id is None:
-                                lun_id = vlun['lun']
-                if lun_id is None:
-                    # New vlun creation failed
-                    msg = _('No new vlun(s) were created')
-                    LOG.error(msg)
-                    raise exception.VolumeDriverException(msg)
+                            break
+                    vlun = common.create_vlun(volume, host, nsp)
+                else:
+                    vlun = common.create_vlun(volume, host)
             else:
                 vlun = existing_vlun
 


### PR DESCRIPTION
This basically a revert of the patch https://review.openstack.org/#/c/309613/ done on upstream cinder driver for HPE

We need to revert this patch for customers with high end arrays (typically 20k series) which has large number of FC ports for  the following reasons:

- Patch is applicable only for  pure  FC driver customers, so the problem observed with the launchpad defect will not occur in this environment.
- If customer  has high end 3PAR's which have 80+ FC ports and 10 initiator host ports. Due to the change in above patch (which basically changes the LUN type from Host Sees to Matched set ), the total number of VLUN templates created  is equivalent to number of initiator host ports * number of active FC ports, which is roughly around 800.  This problem compounds with the increase in the number of instances created on Openstack.

